### PR TITLE
Added Training Phrases to support all types of Lookup on Dialogflow.

### DIFF
--- a/Agent/agent.json
+++ b/Agent/agent.json
@@ -22,7 +22,7 @@
   },
   "defaultTimezone": "Europe/Madrid",
   "webhook": {
-    "url": "https://11ca3755.ngrok.io",
+    "url": "https://d4b33de5.ngrok.io",
     "headers": {
       "": ""
     },

--- a/Agent/entities/Artifact.json
+++ b/Agent/entities/Artifact.json
@@ -3,5 +3,6 @@
   "name": "Artifact",
   "isOverridable": true,
   "isEnum": false,
-  "automatedExpansion": true
+  "automatedExpansion": true,
+  "allowFuzzyExtraction": false
 }

--- a/Agent/entities/Author.json
+++ b/Agent/entities/Author.json
@@ -3,5 +3,6 @@
   "name": "Author",
   "isOverridable": true,
   "isEnum": false,
-  "automatedExpansion": true
+  "automatedExpansion": true,
+  "allowFuzzyExtraction": false
 }

--- a/Agent/entities/Team.json
+++ b/Agent/entities/Team.json
@@ -3,5 +3,6 @@
   "name": "Team",
   "isOverridable": true,
   "isEnum": false,
-  "automatedExpansion": false
+  "automatedExpansion": false,
+  "allowFuzzyExtraction": false
 }

--- a/Agent/intents/Default Welcome Intent.json
+++ b/Agent/intents/Default Welcome Intent.json
@@ -26,7 +26,7 @@
     }
   ],
   "priority": 500000,
-  "webhookUsed": false,
+  "webhookUsed": true,
   "webhookForSlotFilling": false,
   "fallbackIntent": false,
   "events": [

--- a/Agent/intents/Default Welcome Intent_usersays_en.json
+++ b/Agent/intents/Default Welcome Intent_usersays_en.json
@@ -1,6 +1,6 @@
 [
   {
-    "id": "27034596-81b8-4f6b-8d37-ff8ae320b772",
+    "id": "bebb1c1d-59d2-43af-99e6-42d4eda2f593",
     "data": [
       {
         "text": "just going to say hi",
@@ -12,7 +12,7 @@
     "updated": 0
   },
   {
-    "id": "52b397f6-92e8-4c23-a365-c857ecf4a077",
+    "id": "c5be0862-ae4d-4634-becc-c3d8c2ca3ed0",
     "data": [
       {
         "text": "heya",
@@ -24,7 +24,7 @@
     "updated": 0
   },
   {
-    "id": "1a0ebf38-3834-4bfa-8d58-c546d2596329",
+    "id": "fd929ec3-178a-460b-9e16-b981c596919a",
     "data": [
       {
         "text": "hello hi",
@@ -36,7 +36,7 @@
     "updated": 0
   },
   {
-    "id": "5c58b89f-d5eb-4541-86e2-5b1b6855b0c7",
+    "id": "d4f044fa-1394-45ff-a0a4-b55ae448da0b",
     "data": [
       {
         "text": "howdy",
@@ -48,7 +48,7 @@
     "updated": 0
   },
   {
-    "id": "92289975-f41a-4dd4-b866-6b6439e0e5e0",
+    "id": "98b1e3a7-b349-4f7e-bc13-a4752ffb57ac",
     "data": [
       {
         "text": "hey there",
@@ -60,7 +60,7 @@
     "updated": 0
   },
   {
-    "id": "51dd64d6-7d17-48d5-b2e0-6dc20444517f",
+    "id": "628e8738-ba50-4d56-9b98-d05f28b48e04",
     "data": [
       {
         "text": "hi there",
@@ -72,7 +72,7 @@
     "updated": 0
   },
   {
-    "id": "7449af69-cd63-4429-940a-e5c462d4259d",
+    "id": "6c521d90-6939-42a3-a02f-04888abff19c",
     "data": [
       {
         "text": "greetings",
@@ -84,7 +84,7 @@
     "updated": 0
   },
   {
-    "id": "a0ea215d-c658-4783-bb3e-7ae2e6da3c77",
+    "id": "eb84fca5-4167-4ff0-a47c-b713d87e0035",
     "data": [
       {
         "text": "hey",
@@ -96,7 +96,7 @@
     "updated": 0
   },
   {
-    "id": "ac1ef016-01df-474c-9680-cc05104fc89d",
+    "id": "57bd2fe0-671f-43f6-90e1-1f2a30c6bf73",
     "data": [
       {
         "text": "long time no see",
@@ -108,7 +108,7 @@
     "updated": 0
   },
   {
-    "id": "7cfaa202-d652-4e7b-92a8-436368c00e7a",
+    "id": "f3530e49-a991-4d0d-8b84-182280ea88f7",
     "data": [
       {
         "text": "hello",
@@ -120,7 +120,7 @@
     "updated": 0
   },
   {
-    "id": "b652571a-9acc-4600-a612-e32d91aed6f8",
+    "id": "ab4f4bb9-3e5a-4b7e-b153-d631bd8cbfde",
     "data": [
       {
         "text": "lovely day isn\u0027t it",
@@ -132,7 +132,7 @@
     "updated": 0
   },
   {
-    "id": "cec42897-2178-47f6-bdf1-5b0dc75d6a92",
+    "id": "06a086dc-b5c9-48ae-8ea8-2f3fee7634b8",
     "data": [
       {
         "text": "I greet you",
@@ -144,7 +144,7 @@
     "updated": 0
   },
   {
-    "id": "b7588c08-a211-4eab-8a90-d401444fd2b4",
+    "id": "1541e97b-55a2-4e05-b780-2e35b370d7b6",
     "data": [
       {
         "text": "hello again",
@@ -156,7 +156,7 @@
     "updated": 0
   },
   {
-    "id": "32f845e9-788b-49f8-a581-f7a14030b26b",
+    "id": "caceaeb8-ca72-41be-a619-147abfbf128b",
     "data": [
       {
         "text": "hi",
@@ -168,7 +168,7 @@
     "updated": 0
   },
   {
-    "id": "a33f8952-28da-46ed-92e8-86e8f29fa1d2",
+    "id": "9b75510a-d184-4a17-83fe-1c5ee43a0f58",
     "data": [
       {
         "text": "hello there",
@@ -180,7 +180,7 @@
     "updated": 0
   },
   {
-    "id": "5503f1a5-2346-495e-bc92-b89acc8ca83e",
+    "id": "d92415e8-fe0a-41f0-a14a-966f137b0136",
     "data": [
       {
         "text": "a good day",

--- a/Agent/intents/Fallback no Team selected.json
+++ b/Agent/intents/Fallback no Team selected.json
@@ -1,0 +1,27 @@
+{
+  "id": "8b05584c-fdeb-4918-829a-4018521c9cc1",
+  "name": "Fallback no Team selected",
+  "auto": true,
+  "contexts": [],
+  "responses": [
+    {
+      "resetContexts": false,
+      "affectedContexts": [],
+      "parameters": [],
+      "messages": [
+        {
+          "type": 0,
+          "lang": "en",
+          "speech": "You have not yet selected a Team. You can select a Team by saying: Select team Teamname."
+        }
+      ],
+      "defaultResponsePlatforms": {},
+      "speech": []
+    }
+  ],
+  "priority": 500000,
+  "webhookUsed": false,
+  "webhookForSlotFilling": false,
+  "fallbackIntent": true,
+  "events": []
+}

--- a/Agent/intents/Get Artifacts.json
+++ b/Agent/intents/Get Artifacts.json
@@ -19,21 +19,6 @@
           "isList": false
         },
         {
-          "id": "ea90f1d9-dbbf-46c7-b485-35a88fe4d56a",
-          "required": false,
-          "dataType": "@Artifact",
-          "name": "Artifact",
-          "value": "$Artifact",
-          "prompts": [
-            {
-              "lang": "en",
-              "value": "What type of Artifact are you looking for?"
-            }
-          ],
-          "defaultValue": "Picture",
-          "isList": false
-        },
-        {
           "id": "4c931624-3006-4de1-b64e-bb85f68eee06",
           "required": false,
           "dataType": "@sys.any",
@@ -51,6 +36,7 @@
         },
         {
           "id": "1e90cbd3-cf3c-49df-848a-9a681eca0938",
+          "required": false,
           "dataType": "@Team",
           "name": "Team",
           "value": "$Team",

--- a/Agent/intents/Get Artifacts_usersays_en.json
+++ b/Agent/intents/Get Artifacts_usersays_en.json
@@ -1,15 +1,11809 @@
 [
   {
-    "id": "036ddc60-cdb7-4c29-92f7-70ce3902034f",
+    "id": "3a8309b6-b9d8-4eee-82de-c114f1ccd3a5",
     "data": [
       {
-        "text": "image",
-        "alias": "Artifact",
-        "meta": "@Artifact",
+        "text": "Get me an image",
         "userDefined": false
       },
       {
-        "text": " by team ",
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731808
+  },
+  {
+    "id": "212ce6b3-d6c1-425f-89dc-1463bcc67060",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731808
+  },
+  {
+    "id": "f5bcb055-682d-475f-a9d0-518eb937a5e1",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731808
+  },
+  {
+    "id": "1ecb5970-2940-4a22-8f47-891a5a1a87a3",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731808
+  },
+  {
+    "id": "15a53e18-a682-4f77-9138-603943467e6b",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731808
+  },
+  {
+    "id": "e65d4ba7-8744-428f-b80d-2fa7eaf707ed",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731808
+  },
+  {
+    "id": "c064f4f2-fe01-4c01-a338-b0ee13b66872",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731808
+  },
+  {
+    "id": "e7de9bb4-dc8d-40fc-81cb-4252446f6071",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731808
+  },
+  {
+    "id": "4bd30dad-1501-4951-bad6-b9260f619c21",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731808
+  },
+  {
+    "id": "b74b523e-45b1-47a2-9e1e-f252229ceae4",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731808
+  },
+  {
+    "id": "a7613d0c-1a6f-4cd1-b879-57e733ddf44d",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731808
+  },
+  {
+    "id": "a61d7206-72c4-463c-bb7e-2045c14e7d25",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731808
+  },
+  {
+    "id": "401bd4e4-b0f0-4a47-a1f6-f85d5817a0cb",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731808
+  },
+  {
+    "id": "6c0905b2-4d10-4876-82f4-de99c3c9a9b0",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731808
+  },
+  {
+    "id": "58f60cfc-2886-41f3-be85-d4f39382dc80",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731808
+  },
+  {
+    "id": "9d447f83-3249-470f-8d4e-1171bf0a4bb1",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731808
+  },
+  {
+    "id": "c837d278-85cd-4f88-b030-868da98c2e28",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731808
+  },
+  {
+    "id": "33b88f1c-9b42-40fd-a2ed-ea4f6feab328",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731808
+  },
+  {
+    "id": "ba935d46-5992-44fc-a325-c4086b925f0e",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731808
+  },
+  {
+    "id": "53784596-7d12-4531-b83f-e23cf6b0eea2",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731808
+  },
+  {
+    "id": "ad77f9b1-5849-4e95-85ff-3a86ea75c654",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731808
+  },
+  {
+    "id": "d327419b-5261-414e-b883-78c9fe652eb9",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731808
+  },
+  {
+    "id": "d551e5e0-fb1f-4725-a3e9-7eb22d7f7fdd",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731808
+  },
+  {
+    "id": "3b6e2315-876c-47bc-ae75-147948d4db84",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731808
+  },
+  {
+    "id": "2d6154e8-eec7-46b8-a39a-0254bbf60202",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731808
+  },
+  {
+    "id": "04a6c895-2f81-48e1-bacf-5ce5901f67e7",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731808
+  },
+  {
+    "id": "9c461bbc-6e3d-45b1-b1de-cc5751057112",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731808
+  },
+  {
+    "id": "3183a551-39b9-4611-8584-bd51e18ba501",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731808
+  },
+  {
+    "id": "17c57c77-e5bb-4f55-b8b0-3cf2d1924073",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731808
+  },
+  {
+    "id": "8e5daeb9-5aec-4165-91ce-5b5c2c1ab906",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731808
+  },
+  {
+    "id": "0c8e6c88-d52e-44fb-8aef-7b16833dcbb1",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731808
+  },
+  {
+    "id": "ba201a77-8f1d-4323-9749-98b94d867d6d",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731808
+  },
+  {
+    "id": "f41b7361-f87e-4bae-9009-a50bbe893ad5",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731808
+  },
+  {
+    "id": "3e8c8098-f2d9-4308-a627-2ce7ee570027",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731808
+  },
+  {
+    "id": "f42b8279-0dc8-4fd6-89f6-2a0b6d6c4fd6",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731808
+  },
+  {
+    "id": "6b36a502-b180-4d7f-bdfc-6b9212b55e9c",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731808
+  },
+  {
+    "id": "295efd5f-13b7-47a4-ba6f-a04a3fdc19b3",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731808
+  },
+  {
+    "id": "e95fa4b5-105a-488f-97b1-c4b595546a48",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731808
+  },
+  {
+    "id": "033aa8c6-1021-4e64-8115-3950ff6b7e42",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731808
+  },
+  {
+    "id": "dd0a4f30-777f-4284-9f16-3f945cf2abc2",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731808
+  },
+  {
+    "id": "e659c258-94d7-488f-94ef-854366268496",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731808
+  },
+  {
+    "id": "bbd4e2bb-4603-44d5-8c66-f0a55293db12",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731808
+  },
+  {
+    "id": "5e863534-3f16-447a-8d2d-61ff76a39ffd",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731808
+  },
+  {
+    "id": "d8d9335b-50df-4c40-9822-18a0c5fe3244",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731808
+  },
+  {
+    "id": "20868043-e94e-494f-a47a-0b4d4ad825d3",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731808
+  },
+  {
+    "id": "435748ce-f3db-4689-9cdb-b7b97baff661",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731808
+  },
+  {
+    "id": "643d7bab-5d52-45ce-9897-53424e5806ab",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731808
+  },
+  {
+    "id": "9ba7accd-ae9a-4c65-91fd-6fdd42b93d76",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731808
+  },
+  {
+    "id": "a97493cd-d02a-4e47-8e90-c0331d1c6a41",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731808
+  },
+  {
+    "id": "d4ed7213-c425-4f93-9c8d-5148d836e998",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731808
+  },
+  {
+    "id": "85220e72-9892-4d05-8651-332563d45c7c",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "c0ccfded-1588-4303-8bb1-4e49e8673005",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "077c2475-2848-4952-8122-4d8fd8eedbb7",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "332df78d-be93-4040-9dcd-0632063a77c6",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "9b40aa7c-0dce-4b01-917f-94e68fc5324e",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "59749a55-04bd-4799-9bdd-df34a7d27452",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "e632b69b-cdb8-4bc7-835a-5ea64cf7d726",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "9ad1b849-b14a-4969-abe4-f6f7a253aea6",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "352b9deb-37bb-4acd-88eb-3a1eb2cf081a",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "9192cf73-13d2-48be-9b95-5ff3b1fb3436",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "6d75fefa-515e-41b9-a6cd-39cab7bbc8e4",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "46b98321-e486-4ed7-a4ac-0dfa031aa990",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "48dee48d-2a64-4c88-9bbf-0a324982296d",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "abf239e5-0a04-40f6-8253-dc29fd41e316",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "bb4604f2-5782-4512-9592-5f69b986095c",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "c7a7ec99-0a2e-4f10-8cf6-e4271175fd36",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "cfc3f8f9-0f99-4134-9ce4-a11a944a388d",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "f8f53259-a45c-46d2-adb3-0035a08d95f2",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "96fc1b53-6ca8-4eec-a199-5160bc86be3a",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "2d7cac46-c9c9-474d-9d57-515a2889719c",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "7884e776-e732-4973-887c-c84baee49b6a",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "22223f1c-f64b-45f1-b6e5-030aae6bc9f6",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "f6ab18c6-7bbc-4e36-a2eb-1e1e98216538",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "d602ef8a-54bf-4680-bd16-7d15f06f5dc0",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "82515590-7a0f-4762-b867-992155cd8e20",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "61347afa-23e1-4a58-9d09-0a869b1c6e0b",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "2109785d-a3f3-44c1-9ccd-1a3bb5c9fea5",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "a60a75c9-4e67-4e85-a7cc-a22e330cba87",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "07358785-c898-4b93-98ac-4487bec9eafc",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "d27e5902-39e4-4ac5-ba77-9eacb8b9e118",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "8682d93d-5f34-427a-a0d1-0cd1b5f54cb1",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "350fbc15-51ae-4efd-871d-5264bb8472eb",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "ec987b99-0e59-4bed-bf22-5c9967763cb0",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "2c79ed73-ee23-49fc-9893-f5a8d47bcf29",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "e45d57dd-73b2-47c3-860d-8d39ab26d4fb",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "84c99779-39d1-4e36-9989-6d5209d73e78",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "e3082fde-e86a-4eca-9e87-07c9bdc7e270",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "e9c6a2af-4864-4c5d-bfba-a4ed9600e847",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "f56abb18-9731-40b1-864f-693cf00e2350",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "8620f5a1-7a93-49c5-a169-10f1a060c0cb",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "41d90670-0229-432c-bf0a-4a868fda49e9",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "3f161c2a-807f-4bf1-ba1e-20b644b77cd4",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "03c8c41f-abfa-475d-bcd1-0911a9859969",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "e7f6a1b3-d3ef-496d-8b69-fee8b828fa65",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "3f52da4f-a7bb-41f8-9284-f962f1b6c518",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "c085a9d5-7750-419f-b1db-699c43a1a803",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "f4feffaa-fe57-4431-8af4-2a0ebb1ef3cd",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "0ddf9dcf-0d79-465f-9f6b-23c33cf4ae2b",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "ccfddcdd-10de-43ee-8859-0f6884bad94d",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "1cb4a8c9-54a6-4b3d-9f8d-b2c11cfc48bd",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "681dfdfb-edcd-46e3-8dd6-22361159d666",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "0e4ac97c-40dd-4a29-9c57-8bae1ad10faa",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "8c34e64f-0063-445e-9aa6-009016188125",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "c62ec466-dcf7-494b-a3c1-1a360c224e18",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "3332bab2-35ad-4c3d-bb87-f25f46a14b25",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "2cb4bb7c-cbc0-4dba-97bb-f9b46be3d740",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "35c86d38-c1ce-491b-a0d9-5304b6fb49ec",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "d813e70e-a480-4b1e-98a1-a17e23fb93c7",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "36bb4dba-adb7-4e76-a397-d0cce5ea7078",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "e5e0fb39-f231-401d-bdae-f565e73e1344",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "03fcafaf-15d9-47d8-9332-26f2066d9042",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "bc8fb4cc-9aee-42fe-a1c5-71fcb6e24d94",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "0f989cfa-ca55-45c7-8f1e-85ba7c812b82",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "8aa1a0b7-5de7-4a94-9872-fd072b3ce3ff",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "08a960b7-be99-4c73-bbb7-377fe02bd9fa",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "2f4487b6-0b22-48ab-8305-39a4f5a58db0",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "d0bebb78-96ad-464e-bd02-38c710b613eb",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "1d63be30-620b-4ae5-8b35-1dccd355876f",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "04a0869f-e4b7-4f8e-a6c1-03fb7737252d",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "5270e752-8d45-4366-a764-82e8e50fe850",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "7f5853b1-cf1b-4256-9b93-7eab7a7dfc7d",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "3c9102de-65e1-4b69-a782-520c1938c60f",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "e9e5b375-d112-4417-8250-0932160ce08a",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "3e36bfcf-befd-4587-a181-5c955c98fc23",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "9e274a1c-2bdd-4fa6-b364-f130824028c7",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "9a2d3968-d1dd-4b18-af9c-23dbd9d39eec",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "40aef503-6811-433b-9569-5c0f87048f17",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "6e528f4e-29d2-47bc-8cb1-71ece1543abc",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "cce138c8-c7ea-4be0-8862-162ad92b5cbd",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "b744e66d-a956-4727-ad47-a743a57f0f4d",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "9800676c-15fa-441f-afc4-00fc5294da34",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "d710303c-10fd-433d-a2f1-9bb1e6161ced",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "730ede7c-32ea-454d-bf27-e9493ee1eec0",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "9bc1cd4f-7856-4ac5-9d36-5818cb681c3e",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "dc49b68e-569c-4327-8c17-af1a5575ba06",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "639c4b62-ef9a-4d71-84fd-73653659da96",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "76c827be-dd38-4cc7-89bb-d217c45920a2",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "1ba00365-e4bf-4504-a019-c8c8092021c8",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "1070d677-f33a-4bf1-beb9-fd7cec413a5f",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "b1c85b04-6225-4332-a970-ac547384a5de",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "6616f331-6b49-4709-a10f-c49e923405ac",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "c15fb7be-d2f2-464d-a0fa-2d2502d812d3",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "351ff024-c2d3-41e8-b7da-4a6f5a2d8d3a",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "2a782b61-c329-4bc4-b7a7-d3df64d185d5",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "0cde150d-9d87-4cd4-9e4a-0927977bef0c",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "f5bd270b-1ac2-4593-bf03-312483a721e4",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "02aece3f-08cd-4232-8734-7671935e3fd9",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "002c1f48-09f6-4f35-add4-c188b116258f",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "d10e2cb4-1c09-453b-8202-98a8f2bd54f9",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "1077b761-3a1e-4e61-9116-f29bafc92205",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "6c333921-291a-41f6-9b15-fba8e8831414",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "8526ce55-9f53-49f0-af43-28a01918f570",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "1d4105e0-825f-4734-85e9-ba8be295fae8",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "165d700c-7f5b-4358-85be-f03c5a26d5fc",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "e850deae-9a64-4368-a1d7-0414c1001d16",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "22b39103-b2fb-4e3f-81ec-023455f4ff28",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "b5e414e5-e53f-4af4-ae5e-d2ade549ff2f",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "8ce2493e-6b95-4dba-b82f-315ca9671c6f",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "b0e18304-8215-4cf5-aeb2-21b1ca2a2b71",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "fd3500bd-6783-42fb-a949-efb25a12391c",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "dbdd4597-6d90-4268-af0c-1f24bb74c962",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "3148c5fc-b215-4ee6-aaf1-1a3f24aedbd3",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "08b527c5-992c-4751-b9ab-decaf96651da",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "49a9fcc9-4955-4b94-8728-302a8e8eec46",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "0c8b5880-08cb-435e-888e-602c9e30ea6d",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "f97f8ff4-baeb-4f84-8a8f-51ef8746b66d",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "c5497839-11ce-4acf-ab5b-62c55676581a",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "8c81afec-66cc-41bf-94a1-65e9853be58d",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "a12b53e2-c5e9-41bd-a923-50835f503769",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "bf784cab-f90e-4975-82f0-57e8c2261523",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "35323f54-b322-43a7-b73d-2d20ded47a3d",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "a315335c-33de-4997-b68c-f66cdff29f9c",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "516d4107-d8b3-4913-a7ee-1ba6b09f06ee",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "81e75ec2-dfd2-46d6-b5bd-f32c6ed2b67e",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "50d8d168-5a56-47b0-91c9-d0756e9fab83",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "d2b9cd18-d587-424b-94db-cdca47246a0c",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "1eb19339-cc17-4cd2-bd1b-5ff56f831f0f",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "87b22967-5393-45f4-8922-525a47407ba6",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "546b4ccc-ed19-452a-a43d-bba84c5eecc5",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "ca0083de-20bd-4d96-8af8-fff632e9aa0b",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "760d5a1e-f3ab-476f-b0fa-0d828bc8da1a",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "d5518b5d-1e55-4288-8d5f-1dcc7d38c296",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "e48a7bc3-eeb3-49b2-863a-4c55ef6c8c10",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "d64e5948-2c90-43d2-8642-0a0ea2ae3486",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "71b1b6ca-9652-4f9c-a426-eae871e16db8",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "74d86a35-cbab-4924-ab13-9ad5c9baa640",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "1c3b99d6-c866-494a-b2ef-a073558b0ecf",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "3ac429ef-c85a-4873-b12f-6177830e0532",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "b85c6202-fc59-40ea-af34-2079e2442d17",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "42d743a7-84f7-4321-a5e2-727447210181",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "97187eca-5171-468f-a163-de31e468e115",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "3d47b6d4-ac65-4c96-802d-c0f5a7dc3ec5",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "429653d0-1e25-4d32-b306-123a7f30f84e",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "7c3b318f-83cd-4ad7-bd56-bb5fdd3191be",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "7da2a2ab-4086-4a65-ab6e-dcdad95e1f39",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "ca823264-52bd-4e81-b8af-c8c250571cb6",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "f4cae1db-1330-4ce1-ae39-1330a8e1dbfb",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "96f5fb2f-9d55-44df-a425-55d044373e4e",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "05d3bf87-1696-4c74-9329-4c2404359356",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "06175fb7-4741-4dde-b316-cc029e646f6c",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "9790faf3-1e44-4745-b49b-a3ea244d0ad0",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "708a2af4-305d-4e92-bf3f-c7f7b7559d15",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "1ed859e9-f992-4721-b102-6140d96242ca",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "e422b394-1ea9-45cc-8cbe-4fbfd8ef0807",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "a567414f-93c5-4054-8eb3-9d3162ded88b",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "94eca3a8-918a-4c99-8fcc-ce78dfc79475",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "e540d655-f3cd-4cdb-82de-a70d9493df28",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "db73c0de-6624-412c-8db6-02385137de4c",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "cbd41084-0e94-4abf-97f6-ef957d1240fe",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "d695decd-9cfa-4689-9bc9-467b079a2a61",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "fa3d13c9-25b7-489d-9513-92eee2348944",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "043077a3-6c2b-4094-9270-4a5a8ba154c5",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "4969edda-1a47-424f-a766-c6aad6d98082",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "39f592a8-3dc8-4dbf-95af-6f8d50d854f1",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "bfcfcee1-1627-4a26-8195-4dadcc91a364",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "56cdb388-634f-481a-91c2-d6c2ad17d047",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "5b9cbeef-550c-4426-9f4f-67195991c8f7",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "a0977496-2a93-461e-9c69-2787cdcc0a6c",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "e98f9a6e-9449-400c-9bc2-9d92a6286fbf",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "682dda2e-1a48-44fa-aeb3-c9b86863ae7c",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "d4dcb7e7-ced3-428c-aa45-0f7253abbc9e",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "5a6f94fd-d8be-432d-a525-a63a34e666b1",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "625abccc-7742-4cc1-bde9-aaeeab7aedd3",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "974b019d-3d6b-4d65-a0c1-13b0a92306ce",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "7d2c2b2e-3c20-456b-98bd-1a6336108554",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "4246089b-b3da-40d2-848d-a85a9a7a0a68",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "b405fcfe-4e63-4428-8ff4-acedb11ec93b",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "a9409c8e-fcad-4d5a-9475-129ad8e7692a",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "7d1840d9-53d2-4edf-a965-394d6d55673c",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "0ef80ce7-f5fd-4853-bb17-0ee8f8428426",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "24759e8d-c5d2-4ab0-b9f7-15739cfe246e",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "07eb9345-deb1-42bd-a851-c20a47948b75",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "a12cc802-40a5-4ebb-b54e-12db3777f27f",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "d6db3de4-3dc5-46f1-83e7-aedf319ac222",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "a8f2b43c-0453-4446-9785-42102515a926",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "92b1e118-2f42-4834-8b39-31ec9e6db60a",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "17ea4f86-e988-4485-8a47-78dbebc7ea5f",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "af6c4ef9-4177-4699-85be-e076b44622a1",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "1427b824-501d-4193-b08d-16843180a216",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "58e6bfdf-b506-4723-9cdc-8255ecad4901",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "c8a02fc5-3910-4c2f-9e8f-934f5aaaa48f",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "f241eb50-041f-49de-81f4-f9ce55f1cf7c",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "f65eee50-ec62-4960-88b7-93f23ad3a47d",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731809
+  },
+  {
+    "id": "d915dcdb-e7b6-4ae4-b723-06b4cb276aff",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "79ff805b-f164-470c-9545-0d4254d3ebe0",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "be022728-aae3-4452-a6ee-aecb02dddd6d",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "4eb0dabd-d9c8-41b3-90ed-b466e813bc4a",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "8daf505d-bcd6-47b7-80c8-b5d6fc46d7d0",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "4da67744-c569-41aa-9cf2-5a7716ee9c07",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "79e87ab1-f9ae-46f0-80e5-84a99f1e996e",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "754b82de-ee13-44db-8886-bd1ef6adaa28",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "1cead5e0-165b-4fb7-aec4-0181de165c36",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "267cbe99-014a-4b93-aa9b-d3e27d4b355f",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "1eaf0add-60bd-4c54-89c8-21b7e34361d1",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "9173e722-ab28-4595-965c-a0af995a8101",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "aef05585-ceb7-4300-a839-292c2d6ed3cf",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "4293b433-bb49-4be6-9e35-ab454c281ff5",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "a11e79cb-7e70-4e2f-bae8-8c413e7217b1",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "08e12881-35cd-4953-a248-3a0b263bf343",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
         "userDefined": false
       },
       {
@@ -23,7 +11817,7 @@
         "userDefined": false
       },
       {
-        "text": "tag",
+        "text": "tags",
         "alias": "Tag",
         "meta": "@sys.any",
         "userDefined": true
@@ -31,47 +11825,27 @@
     ],
     "isTemplate": false,
     "count": 0,
-    "updated": 1551279911
+    "updated": 1554470731810
   },
   {
-    "id": "10f7381e-3ef4-48bc-b305-9ba143c5a1d3",
+    "id": "d3b4946a-dae3-4f30-af20-002038aed230",
     "data": [
       {
-        "text": "show me an ",
+        "text": "I need an image",
         "userDefined": false
       },
       {
-        "text": "image",
-        "alias": "Artifact",
-        "meta": "@Artifact",
+        "text": " from team ",
         "userDefined": false
       },
       {
-        "text": " about ",
-        "userDefined": false
-      },
-      {
-        "text": "alexa",
-        "alias": "Tag",
-        "meta": "@sys.any",
-        "userDefined": true
-      }
-    ],
-    "isTemplate": false,
-    "count": 0,
-    "updated": 1544613940
-  },
-  {
-    "id": "461419a5-b6dc-4660-8db0-e96b36ea78be",
-    "data": [
-      {
-        "text": "image",
-        "alias": "Artifact",
-        "meta": "@Artifact",
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
         "userDefined": true
       },
       {
-        "text": " from ",
+        "text": " tagged ",
         "userDefined": false
       },
       {
@@ -83,139 +11857,31 @@
     ],
     "isTemplate": false,
     "count": 0,
-    "updated": 1544606907
+    "updated": 1554470731810
   },
   {
-    "id": "4fc168b4-301e-4fe5-9438-ecfa0a3c6e89",
+    "id": "64abcf67-bbe6-4e07-836d-60b210e6f8b4",
     "data": [
       {
-        "text": "image",
-        "alias": "Artifact",
-        "meta": "@Artifact",
+        "text": "Show me an image",
         "userDefined": false
       },
       {
-        "text": " with ",
+        "text": " from team ",
         "userDefined": false
       },
       {
-        "text": "blah blah",
-        "alias": "Tag",
-        "meta": "@sys.any",
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
         "userDefined": true
-      }
-    ],
-    "isTemplate": false,
-    "count": 0,
-    "updated": 1544606291
-  },
-  {
-    "id": "f8a7fc83-e6d3-45fc-bbe3-2707f45cd00c",
-    "data": [
-      {
-        "text": "image",
-        "alias": "Artifact",
-        "meta": "@Artifact",
-        "userDefined": false
-      },
-      {
-        "text": " about ",
-        "userDefined": false
-      },
-      {
-        "text": "blub blub",
-        "alias": "Tag",
-        "meta": "@sys.any",
-        "userDefined": true
-      }
-    ],
-    "isTemplate": false,
-    "count": 0,
-    "updated": 1544606291
-  },
-  {
-    "id": "69faebb9-8907-4484-ae94-4ce363c978b4",
-    "data": [
-      {
-        "text": "image",
-        "alias": "Artifact",
-        "meta": "@Artifact",
-        "userDefined": false
-      },
-      {
-        "text": " ",
-        "userDefined": false
-      },
-      {
-        "text": "from 3 days ago",
-        "alias": "DatePeriod",
-        "meta": "@sys.date-period",
-        "userDefined": true
-      }
-    ],
-    "isTemplate": false,
-    "count": 0,
-    "updated": 1543847606
-  },
-  {
-    "id": "681cccd5-5d73-43e6-8511-2b93ef8f359d",
-    "data": [
-      {
-        "text": "image",
-        "alias": "Artifact",
-        "meta": "@Artifact",
-        "userDefined": false
-      },
-      {
-        "text": " by ",
-        "userDefined": false
-      },
-      {
-        "text": "Arne",
-        "alias": "Author",
-        "meta": "@Author",
-        "userDefined": false
-      },
-      {
-        "text": " ",
-        "userDefined": false
-      },
-      {
-        "text": "from yesterday",
-        "alias": "DatePeriod",
-        "meta": "@sys.date-period",
-        "userDefined": false
-      }
-    ],
-    "isTemplate": false,
-    "count": 0,
-    "updated": 1543847606
-  },
-  {
-    "id": "684f64b3-5319-425f-acae-567d78b5f857",
-    "data": [
-      {
-        "text": "image",
-        "alias": "Artifact",
-        "meta": "@Artifact",
-        "userDefined": false
-      },
-      {
-        "text": " by ",
-        "userDefined": false
-      },
-      {
-        "text": "Arne",
-        "alias": "Author",
-        "meta": "@Author",
-        "userDefined": false
       },
       {
         "text": " tagged ",
         "userDefined": false
       },
       {
-        "text": "blub",
+        "text": "tags",
         "alias": "Tag",
         "meta": "@sys.any",
         "userDefined": true
@@ -223,97 +11889,23 @@
     ],
     "isTemplate": false,
     "count": 0,
-    "updated": 1543847606
+    "updated": 1554470731810
   },
   {
-    "id": "d0fb593c-05e2-4208-a433-5cfd0a9205f4",
+    "id": "a5df7cff-c61d-4613-9e32-8a07c6d484c2",
     "data": [
       {
-        "text": "image",
-        "alias": "Artifact",
-        "meta": "@Artifact",
+        "text": "Get me an image",
         "userDefined": false
       },
       {
-        "text": " by ",
+        "text": " from team ",
         "userDefined": false
       },
       {
-        "text": "Arne",
-        "alias": "Author",
-        "meta": "@Author",
-        "userDefined": false
-      }
-    ],
-    "isTemplate": false,
-    "count": 0,
-    "updated": 1543847606
-  },
-  {
-    "id": "cb3ff9f3-b815-4963-ac49-32d60ef2288e",
-    "data": [
-      {
-        "text": "image",
-        "alias": "Artifact",
-        "meta": "@Artifact",
-        "userDefined": false
-      },
-      {
-        "text": " tagged ",
-        "userDefined": false
-      },
-      {
-        "text": "tag tag tag",
-        "alias": "Tag",
-        "meta": "@sys.any",
-        "userDefined": true
-      }
-    ],
-    "isTemplate": false,
-    "count": 0,
-    "updated": 1543510782
-  },
-  {
-    "id": "31087d32-09ca-4730-94da-04e78a607b24",
-    "data": [
-      {
-        "text": "image",
-        "alias": "Artifact",
-        "meta": "@Artifact",
-        "userDefined": true
-      },
-      {
-        "text": " ",
-        "userDefined": false
-      },
-      {
-        "text": "from 3 days ago",
-        "alias": "DatePeriod",
-        "meta": "@sys.date-period",
-        "userDefined": false
-      },
-      {
-        "text": " with tags ",
-        "userDefined": false
-      },
-      {
-        "text": "random large box",
-        "alias": "Tag",
-        "meta": "@sys.any",
-        "userDefined": false
-      }
-    ],
-    "isTemplate": false,
-    "count": 1,
-    "updated": 1543510782
-  },
-  {
-    "id": "d3265f38-99a1-4024-84c8-7e9823135d5e",
-    "data": [
-      {
-        "text": "image",
-        "alias": "Artifact",
-        "meta": "@Artifact",
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
         "userDefined": true
       },
       {
@@ -321,17 +11913,7 @@
         "userDefined": false
       },
       {
-        "text": "whiteboard",
-        "alias": "Tag",
-        "meta": "@sys.any",
-        "userDefined": true
-      },
-      {
-        "text": " and ",
-        "userDefined": false
-      },
-      {
-        "text": "random",
+        "text": "tags",
         "alias": "Tag",
         "meta": "@sys.any",
         "userDefined": true
@@ -339,49 +11921,23 @@
     ],
     "isTemplate": false,
     "count": 0,
-    "updated": 1543510782
+    "updated": 1554470731810
   },
   {
-    "id": "1988d183-8153-43b6-9a9e-a4331cadfd96",
+    "id": "e802167b-0b45-4812-8638-de7d8a9c37d8",
     "data": [
       {
-        "text": "image",
-        "alias": "Artifact",
-        "meta": "@Artifact",
-        "userDefined": true
-      },
-      {
-        "text": " with the tag ",
+        "text": "I need an image",
         "userDefined": false
       },
       {
-        "text": "brainstorming",
-        "alias": "Tag",
-        "meta": "@sys.any",
-        "userDefined": true
-      }
-    ],
-    "isTemplate": false,
-    "count": 0,
-    "updated": 1543510782
-  },
-  {
-    "id": "968d229f-e8db-493b-9d51-8f72c8faaf65",
-    "data": [
-      {
-        "text": "image",
-        "alias": "Artifact",
-        "meta": "@Artifact",
-        "userDefined": true
-      },
-      {
-        "text": " ",
+        "text": " from team ",
         "userDefined": false
       },
       {
-        "text": "from yesterday",
-        "alias": "DatePeriod",
-        "meta": "@sys.date-period",
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
         "userDefined": true
       },
       {
@@ -389,17 +11945,7 @@
         "userDefined": false
       },
       {
-        "text": "Leo",
-        "alias": "Tag",
-        "meta": "@sys.any",
-        "userDefined": true
-      },
-      {
-        "text": " and ",
-        "userDefined": false
-      },
-      {
-        "text": "whiteboard",
+        "text": "tags",
         "alias": "Tag",
         "meta": "@sys.any",
         "userDefined": true
@@ -407,39 +11953,23 @@
     ],
     "isTemplate": false,
     "count": 0,
-    "updated": 1543510782
+    "updated": 1554470731810
   },
   {
-    "id": "300b9529-5616-463d-b112-0f9830a15b91",
+    "id": "daebb288-ce94-44b6-ba60-9c0f775dd293",
     "data": [
       {
-        "text": "image",
-        "alias": "Artifact",
-        "meta": "@Artifact",
-        "userDefined": true
-      },
-      {
-        "text": " with the following tags ",
+        "text": "Show me an image",
         "userDefined": false
       },
       {
-        "text": "whiteboard cluster brainstorm planning cars",
-        "alias": "Tag",
-        "meta": "@sys.any",
-        "userDefined": true
-      }
-    ],
-    "isTemplate": false,
-    "count": 0,
-    "updated": 1543510782
-  },
-  {
-    "id": "4f1811d8-be97-4430-af35-e019b9484992",
-    "data": [
+        "text": " from team ",
+        "userDefined": false
+      },
       {
-        "text": "image",
-        "alias": "Artifact",
-        "meta": "@Artifact",
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
         "userDefined": true
       },
       {
@@ -447,7 +11977,7 @@
         "userDefined": false
       },
       {
-        "text": "whiteboard",
+        "text": "tags",
         "alias": "Tag",
         "meta": "@sys.any",
         "userDefined": true
@@ -455,15 +11985,23 @@
     ],
     "isTemplate": false,
     "count": 0,
-    "updated": 1543510782
+    "updated": 1554470731810
   },
   {
-    "id": "b7bcc321-95e9-48b7-9d5b-770ff70d19cc",
+    "id": "13ff21a4-f9b9-4a39-a800-f06397addd0a",
     "data": [
       {
-        "text": "image",
-        "alias": "Artifact",
-        "meta": "@Artifact",
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
         "userDefined": true
       },
       {
@@ -471,7 +12009,7 @@
         "userDefined": false
       },
       {
-        "text": "whiteboard",
+        "text": "tags",
         "alias": "Tag",
         "meta": "@sys.any",
         "userDefined": true
@@ -479,23 +12017,951 @@
     ],
     "isTemplate": false,
     "count": 0,
-    "updated": 1543510782
+    "updated": 1554470731810
   },
   {
-    "id": "3a730e68-235d-4762-8dc3-85359a038873",
+    "id": "834cdf7f-592f-467e-a505-407bacdfe215",
     "data": [
       {
-        "text": "mind map",
-        "alias": "Artifact",
-        "meta": "@Artifact",
+        "text": "I need an image",
         "userDefined": false
       },
       {
-        "text": " ",
+        "text": " from team ",
         "userDefined": false
       },
       {
-        "text": "from 3 days ago",
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "bb217b4a-d771-410c-9bf1-210c49e4ceac",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "657f46f6-bdeb-4869-a646-398fe6318c91",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "9dbb7f4c-4bb3-48cb-8d49-6d7e64817567",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "ad7dbbab-d00f-46ef-adde-470af524f03b",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "dd246b51-74ad-463f-8fb0-1d963a8a7584",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "27d09cb3-37be-4d22-9f5a-3a79171b2fcd",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "fde1f152-4609-4132-aab5-b50cff14126b",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "6f7d5de8-592a-45ad-a758-814fc0134bf0",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "d5f9328b-eb37-4b1f-8ccf-6f06c3f7b4c6",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "ae6f1e1d-6157-4c30-8d93-eea0e670c634",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "7a5bae73-1b38-4de8-803c-f5330f7099a3",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "596501d4-fb6a-486a-912b-24dad47f84f3",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "90284a21-e0a6-4086-8e35-94ee9912f27e",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "7a208cb4-9684-4b9f-8d40-4fbf0c23c9b8",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "a6973624-9fbf-486f-a370-723c308aa9d9",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "55bc7e51-0f73-4f92-aa4a-888c1d341ad4",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "0bb0ef68-a1a5-4c9f-a812-861a10612071",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "23cd2876-6676-4962-84b0-58257ce2dacd",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "a4f91d68-664e-4965-bb56-5ca18bf90f38",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "3d187980-a0a8-449e-96a7-5fbc2c1d079a",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
         "alias": "DatePeriod",
         "meta": "@sys.date-period",
         "userDefined": true
@@ -503,54 +12969,20784 @@
     ],
     "isTemplate": false,
     "count": 0,
-    "updated": 1543510782
+    "updated": 1554470731810
   },
   {
-    "id": "bb762d2f-d232-42c8-855e-c64b48ccc2e7",
+    "id": "153ff788-70d5-4b62-b993-256fa35521bd",
     "data": [
       {
-        "text": "mindmap",
-        "alias": "Artifact",
-        "meta": "@Artifact",
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
         "userDefined": true
       },
       {
-        "text": " ",
+        "text": " by ",
         "userDefined": false
       },
       {
-        "text": "from yesterday",
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
         "alias": "DatePeriod",
         "meta": "@sys.date-period",
-        "userDefined": false
-      }
-    ],
-    "isTemplate": false,
-    "count": 0,
-    "updated": 1543510782
-  },
-  {
-    "id": "16a8d0dd-24c5-4788-ba9d-836a2e2e9b80",
-    "data": [
-      {
-        "text": "yesterday",
-        "alias": "DatePeriod",
-        "meta": "@sys.date-period",
-        "userDefined": true
-      },
-      {
-        "text": "\u0027s ",
-        "userDefined": false
-      },
-      {
-        "text": "mind map",
-        "alias": "Artifact",
-        "meta": "@Artifact",
         "userDefined": true
       }
     ],
     "isTemplate": false,
     "count": 0,
-    "updated": 1543510782
+    "updated": 1554470731810
+  },
+  {
+    "id": "f1e824b1-8240-4264-b224-40e480a2e0e3",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "b6bca4f8-3ffe-4af4-a255-c1429d35be94",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "cfcd7f8f-bb59-4da1-b7c7-956aaf30cad5",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "536b2da9-9c7d-48fb-80d2-b536fb490ed3",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "9048766e-8b9b-463d-94ef-af158c337fe8",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "bed9f69c-b0e5-4c37-a449-7e5ca890e0f8",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "4d07edca-e8fd-48f1-bf67-e63a1bfbfcbb",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "6bc54368-0b68-488f-b6e8-55d870319101",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "b1c38295-8a23-487a-bb29-57e37dddfbe8",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "bd2404cc-0d3d-4247-a868-da78e3137049",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "a1add82b-8ed9-440f-92e8-4caec003ee33",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "26ef5e04-fc3e-437e-84e4-94469ca16d1a",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "5684e94b-20b7-49ac-85e0-6b98a10e3a9e",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "fa09d42f-3435-478f-95cc-2b85869d55db",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "54be9ac3-9914-43e6-8df9-17f423a5ef8f",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "f34f7eff-551e-4dcc-a350-2b194c55c140",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "c1220393-06f4-4fad-a44d-95b3d867e8b5",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "3ba17e14-60d7-411b-b814-c3269d29f7c7",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "7ad8a6f9-37b6-4c7e-9d84-0121b017dcc5",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "27509c80-58ac-46dc-a1db-750dfff18e07",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "e98fdbab-59ef-4e79-a2c9-4aee989885aa",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "16242965-0877-4d10-ad3f-5e33142e37dc",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "d47dbade-1bbd-4661-912e-dc066ba7ea80",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "e8474df2-f3a3-4342-9c3a-47d38481c90b",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "ede04356-3f74-434e-8020-ade130c80a46",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "f183c821-db5f-4585-b996-bcb6599abf7e",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "d176a81f-ff82-4d94-84d7-3c89f9001acc",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "4c88ee86-3595-49da-a333-a10c4860d85e",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "3abf6635-c546-4fad-ba61-ce079dbc9c42",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "86003aa2-9dfc-41eb-b746-c4c53be2ebc6",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "6891773a-8d34-4e54-87dc-d5ac7055cf62",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "cc3b35a0-bc8b-41c4-997c-b9678d83626f",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "4706c437-4d62-4387-93a5-11a5da4173f5",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "e7403753-88f6-4e2a-86b1-e134eb45a8e6",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "8d027647-9396-43b6-a12d-325601f929d7",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "c5e34044-db2a-46ff-8211-4ebd970e4565",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "43f823f0-7e45-4ceb-81ac-b563036b2ebc",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "971a2863-925a-46d3-b909-6a39516d9f9e",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "53bdee41-f302-4eb4-bc07-dd911cdb1da8",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "20268158-f9e3-4e3e-b4ec-d3ff0074e693",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "7c1cd550-7477-48ae-8199-c6ac38175bd4",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "1099a5f7-96d2-40cf-80ef-e2ddb058066a",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "00286439-13a3-4f13-9310-640a584ed8ce",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "3d85b08b-7a97-4eaa-a1fa-cb07f8e3f38b",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "577799c9-7371-45e6-ab18-4a45f49cd45f",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "44015ff8-ded0-40dc-ba6f-e8654d0d5caa",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "9676fa40-1f34-4cb8-8d02-094f08bc284f",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "a3c1363a-ffe3-4c86-b948-6e65a225241e",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "757ccf35-b53e-4370-9b65-3407ec088e61",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "f2bda092-d971-46c6-9932-480e9469cba9",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "25ee6f87-0b00-4ec7-9ff2-2a6297ba0b00",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "94f93384-b6fb-4686-826b-dd11e32e6c8f",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "ad30cafa-e809-4292-9d7e-12841f710fee",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "db27b3e5-d443-4ae5-8d40-cc9bef25cdff",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "2a7dd867-77a9-4d7d-895a-9ffebfe4e0f3",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "ab375e92-41fb-4b02-a3ca-34f9db294b71",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "2da90d96-220a-4e73-87f7-94e8f5efd189",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "2e314882-fd55-44f9-9bc9-ac7fd5f06e1c",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "07dfe94c-fc51-4d3c-93ed-9ff3d927eda6",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "e8c10852-ee16-4d22-92b3-929a0374337a",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "3b01d0fb-217c-473a-b96e-c5f0f95f70a0",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "9f00f57d-0edb-4f8c-92c1-d13c422f0e51",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "3469b448-8270-4001-8cfa-29fce94c31fd",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "120950e8-55a6-4742-b36b-0f2652ada9ef",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "9751e859-838d-40d5-bb43-f0e1885cf05f",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "44ce7767-a5a9-4132-9525-a4c44c63c732",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "e17f15e8-28c5-4f4f-b1d5-0c45c1ac6ae8",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "a00b49ba-56e4-4d93-bad4-c8e58b404e65",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "ad1e8e2b-67de-420a-a5c2-ddb537f9a81c",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "20d01238-d37c-45ae-b36e-c9118e30790b",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "6f2992ee-e356-4a78-a5fc-9082713808e1",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "67658323-a344-4c14-983c-eb9c135e0b1e",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "f24a4219-6487-4c87-a439-9fb564615d59",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "594ccdf5-037a-49aa-8450-86fabd1b33d6",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "849da4c9-ce7e-4aad-9f09-8a26b323a245",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "9c72ffe7-32cf-45ac-b9a6-bae956e54b40",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "685ae9f1-ca56-4b27-9c34-3e5c1ab1d0d2",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "46ab0283-29ee-4b9b-adf4-8f922518d1ed",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "567dbd33-0d24-4a5f-b915-8ee522563463",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "40950dda-70e2-43ee-b56f-28ceaa432fd3",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "3f63b53b-59b5-45f4-b126-0a4316afe65a",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "ccef1f23-bda5-4691-a709-9045f10a5607",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "fdce4cfb-d1f3-499e-99e2-077c1ead442c",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "9c41131a-d2e9-4d18-a39c-97e11209930e",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "72b0a13b-497c-43c6-b175-aa6a42efccc2",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "acb09079-d2d7-48bc-9f2f-60f90ca209de",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "ab978486-3d64-4807-b327-171975c7ae63",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "283cecff-792a-4a82-b0fe-b3acc489ed63",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "97334488-c44b-4136-b50c-871286ddba4a",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "727e1a83-8aa4-42a4-a866-edbef280cf41",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "4a693d0e-e10b-47bb-9f12-41f8862b3557",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "36369086-fabb-4321-be33-331728b2b037",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "3fc4898a-a5c8-4aea-9790-366360657453",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "76d7905a-302e-4285-8660-541adec782ea",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "30480801-2c58-472a-84c7-f0e8a5028a77",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "89d8fad9-f2b0-4e51-9e61-a5d95e45e0b1",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "4e7ebc42-6ed5-4974-95dd-a572a8191275",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "4b6a30d5-1ca4-4ed4-96b5-60f5b82a4add",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "3d74f378-da54-4593-8c32-468b1c6c8528",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "ef491645-fcbb-466e-8916-1641447f0614",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "d429aaa3-f808-47bd-8f06-1c666f7d2ba5",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "f5551b78-1ddb-4ba6-b764-54672ef8ac88",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "1f8441e9-6c03-4ac6-9422-912c5598be76",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "b2aff39e-38de-4b52-b342-856190aa0f66",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "cd5e1f30-bb09-4870-b294-b81f1d811508",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "5353d035-8936-4b4a-97f5-9cb5c336e815",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "b0d3c1e2-3df0-466c-8ca5-e14f50f63848",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "e07da03c-bcd5-4b27-994f-ca573f641cf5",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "8e73a81c-f708-4f30-ab04-520cdb2d19eb",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "a2f6ee0c-436f-42f5-ad6b-8590ff838853",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "7e65bc57-6156-4252-a933-3f4eaf5037a3",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "a65c2e85-82ee-4308-8e4d-fcc52483150d",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "1d32a57e-a604-4714-b67f-92314bcd4288",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "ba5fa202-4b37-4476-afc5-32e5264d8e82",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "a6f5b48b-6c7c-4835-af61-d4757177e661",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "df63b17b-af86-41e6-a8a0-8c8991c5296f",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "cf51635e-e457-4b25-bab4-143761e333b2",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "6fff54ef-0aae-4d27-9d14-3b6eb00ea17e",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "94a72cae-23b5-480d-b6fd-82588c2398fc",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "dec6ce56-041a-4cf6-9b3a-b752ea39df9f",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "d06ee860-e684-46ff-a74d-0264a367a8f3",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "7eba30a2-51a3-4d09-84b1-8ca5e5b2ff3b",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "d7ccff2f-e8fa-4c1e-b828-ab338e684f9d",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "ce424499-5a16-41f4-b865-92749237592a",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "8bddf270-5c06-4f05-aaac-5870747901ee",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "cfcdd7f4-d7c1-4b22-bb0b-584cb4088577",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "ee673cc4-b7f1-49ae-bb4e-f44c5063725c",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "e95f89aa-3dc4-4b33-93f6-7680da7cf5bd",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "46f4750c-89c9-4df7-86ec-05a2f57eedd2",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "3a730909-2a76-4362-9237-89c4d877be44",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "6acf26c6-3842-4545-92c1-f5135743934b",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "c9404de4-0a8c-4ebb-a558-0e41aaa233d8",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "41b5f739-33ea-4467-9631-5417c1e60ad1",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "4c15da59-6bb3-4b7e-8f40-fd7e884e198b",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "b993e496-9d31-4dcc-bfd0-08d6b2b516ff",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "afa18be3-0a19-454c-9af6-c89198a884e9",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "53338579-9ae3-45fa-bfc5-4d980e112fd1",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "e156664e-9393-47e3-b515-29774e9365b6",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "47dfaf8f-fb7b-4147-81fc-4019f80ac677",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "101323ff-02fa-4b08-bfbe-bd3fe77b3f4e",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "75837bdc-7125-491b-a1d3-ff5d83037814",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "4ffa2ad3-bda1-4926-9884-e492115ad7ea",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "8525e928-b344-4b1b-8eb7-95b08ea571d5",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "c1eacb8f-9417-4a0d-8158-0ceb227288de",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "3d907519-7dbb-4a5f-b069-116c8d8647f7",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "b8f936d8-1581-42bc-ae48-0fdac7825ad7",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "1190cf3f-f627-4ee4-bb90-00dd53a0e5fb",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "4fe4ff39-52be-4423-8679-2a8789769d3f",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "f0480468-db4a-452e-811a-3359908be71d",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "0519219d-77c9-44fd-aedb-f36ab45865db",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "2923c7b8-ff77-456f-a0f0-e79b23a45316",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "7db609eb-b054-4513-a5e7-e98fddffa533",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "c87973ed-5a74-479f-a4f2-66a4355e35a0",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "58e4f395-9fbd-403d-87f0-74551909122e",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "bd5ef6a0-bdb2-48d0-a57c-221286fe39ca",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "c496ae51-80bb-4764-bd39-05133c9c447f",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "d94676ec-fe8a-4b10-a7d5-ae1381c70668",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731810
+  },
+  {
+    "id": "57925cf3-40c7-42d5-bf44-ed21eaf7f29e",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731811
+  },
+  {
+    "id": "299f1e69-3d0f-4782-ba32-d026c8462162",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731811
+  },
+  {
+    "id": "1af52413-08ef-45b7-bb75-04a36ce7531f",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731811
+  },
+  {
+    "id": "426e7ec6-16aa-4bf2-bf83-1fc142ddca2e",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731811
+  },
+  {
+    "id": "38505c93-3c41-405f-9e33-b7ee37b30a35",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731811
+  },
+  {
+    "id": "d4fc5184-723d-4a60-b2c2-e961f786d010",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731811
+  },
+  {
+    "id": "cbabdea7-4b58-4493-ba1b-d84a25c494ca",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731811
+  },
+  {
+    "id": "07708830-afd7-44ca-a03c-732f69e8039b",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731811
+  },
+  {
+    "id": "6b8bc764-f02d-41d0-bb58-1d98e56e2e1e",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731811
+  },
+  {
+    "id": "4834b01e-9200-4b33-a60d-6299806ff1a6",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731811
+  },
+  {
+    "id": "97c7aafd-501e-4c76-aba4-bb1c70ccbc4d",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731812
+  },
+  {
+    "id": "b086d89f-21ff-4fb4-82e2-d2bec4c53375",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731812
+  },
+  {
+    "id": "ae63afc9-ad38-4967-80f5-df2bdaa22d2f",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731812
+  },
+  {
+    "id": "dd1b3202-31fe-4b72-ac75-603ce9347506",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731812
+  },
+  {
+    "id": "35fba67b-ee44-46da-9be9-f66fde72f65a",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731812
+  },
+  {
+    "id": "b28e0077-4493-4b23-8773-5f2ea55d9afd",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731812
+  },
+  {
+    "id": "70fe960d-b428-4f03-9c43-05b06e8a7c86",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731812
+  },
+  {
+    "id": "acc8a8a0-70bf-410b-a6c8-d2609e376c35",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731812
+  },
+  {
+    "id": "1e26d7a5-d825-46ce-ba4a-f26b0056eb94",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731812
+  },
+  {
+    "id": "cd26934d-9162-4f09-af0e-37f71740de21",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731812
+  },
+  {
+    "id": "edb42ffa-4f10-4cda-80a7-71925bdd5cfa",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731812
+  },
+  {
+    "id": "f797bf63-3cdf-48cc-b543-f1cf77f999ec",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731812
+  },
+  {
+    "id": "98422e98-c1a4-4de2-9994-ba77c1b121ac",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731812
+  },
+  {
+    "id": "6f79e7f8-0550-47b2-80c8-a8ceb04a16c8",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731812
+  },
+  {
+    "id": "fd348f96-9690-4e5d-88ee-0efdf2e4c847",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731812
+  },
+  {
+    "id": "9a0a35b3-484a-44ac-be32-e1b636560a85",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731812
+  },
+  {
+    "id": "2632f083-8274-492b-b1e4-9b23cbaa69c5",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731812
+  },
+  {
+    "id": "151ba60f-e1d9-401a-8f33-db6d887c26fe",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731812
+  },
+  {
+    "id": "609b1216-b6aa-4274-b774-6091d14c5ee2",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731812
+  },
+  {
+    "id": "d1150330-0c0a-4941-bc49-eda441aa29cf",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731812
+  },
+  {
+    "id": "4aea9654-7426-4dfb-a31c-02f665e5152d",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731812
+  },
+  {
+    "id": "8bbdef9b-5014-4294-bf55-b6264d71e91b",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731812
+  },
+  {
+    "id": "609278c1-d205-49f1-ad87-abdd63ed9635",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731812
+  },
+  {
+    "id": "16d8d68f-bdda-4cbe-8df7-ac1d6bbe9388",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731812
+  },
+  {
+    "id": "581c1df9-13cd-490c-8ea2-af0ad22b8b42",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731812
+  },
+  {
+    "id": "781a2e2c-60f9-4227-ab24-d3567bd9fa51",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731812
+  },
+  {
+    "id": "0cc79718-9c4b-47d3-8854-7abcdef6046e",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731812
+  },
+  {
+    "id": "dbc17ded-8fc6-4c0b-8dcd-631a7e94fe07",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731812
+  },
+  {
+    "id": "0c3da5bf-7192-49e1-ad97-489a3a928718",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731812
+  },
+  {
+    "id": "ab95c6eb-4319-4302-84f9-c63d91128bae",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731812
+  },
+  {
+    "id": "0076a859-76f0-4a84-bb13-195425482126",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731812
+  },
+  {
+    "id": "33d47607-6b3f-425c-bb9b-43d564d9b4c0",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731812
+  },
+  {
+    "id": "2ce69003-49a1-412a-b560-cc78d15a7d11",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731812
+  },
+  {
+    "id": "ac39650e-bb09-47b0-acb1-a47d974ca030",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731812
+  },
+  {
+    "id": "d3de4734-d871-4cc3-b2e4-728af1c30481",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731812
+  },
+  {
+    "id": "25402228-a491-4361-9d8a-dc8b156bfe9c",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731812
+  },
+  {
+    "id": "152519bb-110a-40ce-b7fa-6966f1b1a228",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731812
+  },
+  {
+    "id": "405f12b1-342f-4653-a59f-d3d78f43d456",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731812
+  },
+  {
+    "id": "90c2f3d7-9c7b-43d2-aa83-91114d632f2f",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731812
+  },
+  {
+    "id": "666be864-72ef-4fba-85ce-71ba2f2f36d3",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731812
+  },
+  {
+    "id": "41e091e3-a119-421b-ad7c-d8b0c55140b4",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731812
+  },
+  {
+    "id": "3e78cf28-c7a2-4cdf-995f-695b51ac3d91",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731812
+  },
+  {
+    "id": "6b7d679f-06ed-497a-8ffa-71fa9a4895ac",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731812
+  },
+  {
+    "id": "148cd400-2356-4b39-a937-3cf4e96ba30c",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731812
+  },
+  {
+    "id": "4f11fbf6-7eca-4f1b-972b-d01131b95755",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731812
+  },
+  {
+    "id": "060ecf0e-f1a3-4fb9-8219-dd64945f068d",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731812
+  },
+  {
+    "id": "f064995a-9ca5-49ce-9d04-35551e09e0de",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731812
+  },
+  {
+    "id": "da4fa4d6-a532-46e0-be93-91dd72ebfb87",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731812
+  },
+  {
+    "id": "3b38381c-8327-47b9-bc99-24dff3ad2a39",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731812
+  },
+  {
+    "id": "d959d245-8850-4dcc-9390-7f37655f94ff",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731812
+  },
+  {
+    "id": "e3f0f178-d224-4201-85f0-e36be45b70b8",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731812
+  },
+  {
+    "id": "1ac6fcbe-5043-426a-8b04-424fcac80307",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731812
+  },
+  {
+    "id": "688a6bba-33bf-416c-8774-fa8b8e2616c0",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731812
+  },
+  {
+    "id": "3a18187d-c4dc-421e-bc02-9ea31948647c",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731812
+  },
+  {
+    "id": "829e61e7-80af-432d-a1c3-d2efbc8124a4",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731812
+  },
+  {
+    "id": "e0309ad4-9da9-40ad-a8be-ceeaa5085868",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731812
+  },
+  {
+    "id": "6ae9dce5-e0e8-412f-9bf6-0417986a5ab0",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731812
+  },
+  {
+    "id": "4760a774-d555-45b1-9fa8-3cce0621bc80",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731812
+  },
+  {
+    "id": "cc4148c0-915b-4a4f-aa6b-c42d0de538e4",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731812
+  },
+  {
+    "id": "7c22a83f-8851-40c1-8f8d-9a31eb5142ac",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731812
+  },
+  {
+    "id": "72c20c7a-74e0-48c1-9f36-82e4235943bb",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731812
+  },
+  {
+    "id": "e1218983-55be-4e68-b899-4474631aaa2a",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731812
+  },
+  {
+    "id": "993a2d90-5f6d-4fa1-9692-ffd55f95ad61",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731812
+  },
+  {
+    "id": "4a27f314-d19e-45b9-a851-cdcf048ced99",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731812
+  },
+  {
+    "id": "94033076-1290-45a8-997c-0d57d26548e5",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731812
+  },
+  {
+    "id": "f27a5fe0-5502-4243-8659-42140f3c1746",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "01d80e00-53d6-4747-a9bc-f13291609ce8",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "237fd16b-7385-49ca-991b-85f5954b8ada",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "99cea397-feab-4ae9-85c5-319a4931721b",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "e99f6865-c81a-4f51-b3f4-3ef20a6d9bba",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "a7afe763-14e9-46e0-a18c-fde0c29546e4",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "810da25a-6bf2-4b43-bc2d-aed9880fd16d",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "3861c5ca-21e2-496f-961c-a5f2bc1b3cf3",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "a85f2d43-e85a-4fa5-970a-a46f5ae43946",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "15df1c10-0b5f-4a1c-a8bf-5ae26fe9d427",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "c69d294f-2b87-46bb-84cd-a3ea1e4d30a5",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "e6b2b06d-aaab-4c27-8095-2b936fd7e580",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "c46ee918-498d-4826-81c8-20ad8cd8d9fc",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "e9f14c73-a18e-4baf-8117-d067eeec2630",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "8944c020-7e8d-4173-bc4e-a01ecb834f80",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "bffd3a18-ea8f-4130-aa4c-cc58336a9510",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "9b2a694d-8171-417f-9a3f-694f401ea3ed",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "4c276c75-da64-475b-a7f8-fb67ebb13541",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "9a5f093e-2a45-4f35-9f1f-0bd0feede7f0",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "66048e5e-525b-4db1-8caa-d874898f4933",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "49b8ccc4-4216-4b44-8bbd-8d20bc17e272",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the team ",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "3c8dbb99-1d79-4ed8-960d-ac4a61890eef",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "9b943fec-dd6d-453a-b336-2d6756022d31",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "e541d7f3-1b4b-425c-ab67-1ff4378fc814",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "85d4c8db-4bf2-41e3-96e9-82a11c493048",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "12cf996a-3bdf-45a9-a59d-11c5635b5533",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "7677d4f2-f206-45cc-9abf-606ddf24b507",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "e3f5f817-616c-4af5-a45d-65a3b4d89cc1",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "d1018fc9-adf5-43aa-accb-fc49fd335f08",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "3bc3e560-7acb-44b4-966d-b04e48c2e2ed",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "795a9edd-0be1-4e5d-b785-f95cc2896c8a",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "8f945554-6316-4776-9182-1af5de01fa89",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "e27028ae-8cbb-49aa-80fd-5f3ebed103a5",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "ff80afda-9fb6-4473-9ece-a864f4c9a8f4",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "d97bebe3-a13d-4e27-bdd3-c66ff0e34868",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "9e44c37c-8ee2-480b-b03d-2a60014d5525",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "7e5054bd-173e-4bf7-b2d7-11c33d1cf951",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "f6d89340-4747-4d16-b58c-e7c3d6bd440c",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "27a7c69f-da52-4ba8-a0ec-6f63f35ac69b",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "49f48dac-7c38-41ca-ac8d-fed174981ac8",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "cf720d20-3027-49d4-ae68-e2244d59ec16",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "5f6c554b-87bb-4451-9eb1-4698dbc62b8f",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "0e619bda-a3ab-4095-b85e-2990489662da",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "9bd3d95f-6cec-405b-ac8b-8b4a60c839aa",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "aac2c180-2893-46f3-9b70-82b6dd794f15",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "bd47ef12-75c7-4fc1-8d6d-cd55da2836d1",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "935279b8-a78f-45a9-8f85-be9385364e4d",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "e9912cb1-a069-49e4-9020-d3e88a8890e3",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "e45d5a10-26ff-4859-9ed1-9281d598dbd5",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "459e34a7-6470-447b-9a15-87e4daa771bf",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "ef61b5b6-3755-471a-b627-4eb4843f4dae",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "65402778-a32d-46fb-9627-c791fbe2dbf1",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "508eb9af-5fb3-4ce1-9e59-d9e31a051e31",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "969bcd33-40b7-4d1c-8dcf-71aa496d6a54",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "decb0402-dd56-4e95-83fa-80e64e5f4a89",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "622167cb-0940-47d1-bff9-a940bf4cd647",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "a768ca5e-e66a-4e27-bbd9-2d58d0cbf18f",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "b7f4a8cf-6fec-476f-8c84-b4c74effce24",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "4a46f274-0ac9-4376-b0b7-2abe4d9b6022",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "3e2fde7a-1d2f-46e9-8616-c60ac0d8092b",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "b4b30b67-cda2-4c30-bb01-aa888bf3274a",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "3d01d2fd-43a8-4304-a059-89984c652664",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "0b34ba44-cafe-469c-b058-7783b7c8b0c6",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "8d5a748e-6702-4a77-b0f4-79e3e9f65fc4",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "292e09c3-a6b1-466c-8f52-417e74a8399d",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "16f865ac-c400-41da-ab5e-6228b73c6daf",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "d032e827-9b12-4ac1-92ef-f8b7b5d41801",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "c786bf86-cfa1-43f8-835c-ccb0ae4644ec",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "a63056b0-2441-4b59-ab5d-388821838599",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "6fa8e5ee-cdae-471a-9bc3-241ede9aadf1",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "278df815-5dbf-440d-8a2b-24ad694630f1",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "fe4ffc2e-3ac0-4503-8288-00c33c7e25a5",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "a6c80a59-c493-41ad-a536-8a7599f38489",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "aeaf818b-3dc9-4228-941f-46c4d03fb355",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "b6f801e9-2d9d-40eb-aee4-da9804dc0007",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "f596f44c-92ac-482f-b200-ccc9a45e6acb",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "1b59eb77-77c6-4164-9cf3-afed9820dbc2",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "ef787600-5a3a-4058-916a-97252a43ed59",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "482d50f8-ce70-4b7c-a587-b2c82e0b79f6",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "3679c1d3-05c9-4974-9c5d-371defae236c",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "1f28121b-fd3f-4ed8-a4d2-e20d0851a0dd",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "454905d6-ed8a-4a1a-a6b4-97cbc54cc13a",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "7b690f65-1ba6-4fe4-907b-61ba40005916",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "7f9b1e5b-cef3-4a05-ae20-1559901db496",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "0cc8dbe5-93e8-4f87-9cf8-76f8387199ef",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "4da180ed-f942-42f3-983a-c18eb372ebac",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "0845ba3f-94c4-4564-a734-e969716a881b",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "628e1317-8fa1-48d2-95d1-4ba454f42c02",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "5a313833-d780-4bfe-adca-2b4ea63d9fd5",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "3eff208a-d80d-4595-ae99-3569ba55d027",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "1369a987-9bf9-4d73-ac5d-c2a39323a78f",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "b8356ff9-c515-415e-8573-625a4cb7f1f8",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "3d6b1cba-964e-4d90-917e-0f0a4b5e1465",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "c5b92254-c4ed-41eb-a17f-51e7a9d63c86",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "73ec12d5-d926-4ee7-a9a4-f488b00a8e85",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "bb0d4aa3-93e3-444d-a54c-baa30d3374bc",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "672ec909-f7bd-4fa7-ac8e-12a1c1e497c3",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "90f281f3-0006-46e8-88fc-7af7ac73700d",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "7a37679f-ea8c-47e6-a4c8-1747924e5b78",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "a2f44834-77f3-46b8-b05d-6340437a9c78",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "4063d712-da0e-4f09-affe-3a966bbbca5e",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "049ee767-0a1b-4ee6-a5e3-bb1c1c25d8d1",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "e6c9cf60-04cf-4d1b-9f68-332bccc39eb8",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "5fb8a005-452b-4a83-9eb2-d80185f046b9",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "06f0ce0a-e78a-4ca6-974d-f2d135a84b2a",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "8983ea20-96cf-46d9-9ac8-eee20506ccfb",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "053108ad-49cc-4978-a753-904201165ddf",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "4e4679a7-71d9-4642-b04f-87407804d107",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "cd41f9e7-c286-4b94-8d06-3c0547d3c019",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "efa8f869-154b-4d34-a8ab-5ea406d0210b",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "218638cf-d229-4fc1-b451-83c05db43839",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "e16b5062-433b-4147-a447-c24740aecfbc",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "c3e156cb-768b-400e-b868-fc93ad1bf37d",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "b1d500df-2bce-46c3-b8ad-277d4aea4f9c",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "d7cbd786-302a-4486-913a-65f9606d30ed",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "0005262e-331e-48dc-90a8-d351931035eb",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "cae09e96-b49e-4597-94ab-8e19dafbe465",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "b19a66b2-badb-4dfb-a8ae-e8ef446ea925",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "e449c6c6-57b8-462b-9ff4-f1c6397f2181",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "d668b185-5902-4d3f-85ea-1aa89d232507",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "ccc6e881-92b4-463b-81b7-ea32a23e7c90",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "858683ba-ef5b-48e6-9dcd-57762c1fff17",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "2aa59e83-930c-4449-9393-2f068407751c",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "123edfe2-c614-4f2a-9d13-1d9741c6637d",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "2bdd2f16-4fe8-4ded-a3f0-6d83c2b71bbc",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "556c2ad3-439d-4251-a2d1-5e1b88ce795f",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731813
+  },
+  {
+    "id": "803134be-fd9b-4b83-8ef0-c6f95acdfc73",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731814
+  },
+  {
+    "id": "5c2681f1-5404-4f45-86e8-5840d119a82c",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731814
+  },
+  {
+    "id": "bb5befa3-fc54-4051-b149-ea6192326b53",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731814
+  },
+  {
+    "id": "461ab773-0e62-44ba-850f-94518d198bb8",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731814
+  },
+  {
+    "id": "84e8e24f-71e6-4496-8a01-e08bed8de6cb",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731814
+  },
+  {
+    "id": "8c27a97a-e5a2-4f4c-a46b-a4c0a2d752dd",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731814
+  },
+  {
+    "id": "d29834a1-ee04-49e2-9c00-404bbf34acc4",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731814
+  },
+  {
+    "id": "0346fbff-afbb-4ce5-bfee-8f00798a2977",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731814
+  },
+  {
+    "id": "0ef68cb1-2c7c-4872-b52f-0a7f4fffd027",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731814
+  },
+  {
+    "id": "4b679d05-d941-4ab7-9a60-a1e6366a50a4",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731814
+  },
+  {
+    "id": "70dc1c65-decd-4b3c-b723-eb45cfc6e4e4",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731814
+  },
+  {
+    "id": "ec8d346a-5dfa-4fe6-9129-f239959fb738",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731814
+  },
+  {
+    "id": "7cdae342-3c3a-4b99-933d-2bf3e2c06011",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731814
+  },
+  {
+    "id": "f4798a9a-46b1-4215-aca2-e57f374244e6",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731814
+  },
+  {
+    "id": "7776f203-120a-4b29-bf18-e7d7c651f4ec",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731814
+  },
+  {
+    "id": "f7017a2b-a22c-4a66-9f2b-6a7721f5104c",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731814
+  },
+  {
+    "id": "a6002cd4-c97e-4b5d-b66e-f4d784cbbb43",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731814
+  },
+  {
+    "id": "1cb21ba5-eb25-46c1-bdba-dfdee8b83113",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731814
+  },
+  {
+    "id": "c42326f7-6f6b-4829-9e7d-eef94ba238e4",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731814
+  },
+  {
+    "id": "20935b7e-0659-4918-a1ec-3602bd460c7e",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731814
+  },
+  {
+    "id": "bde50db8-a585-4190-be34-420fd41607f2",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731814
+  },
+  {
+    "id": "b4ee93c8-7642-4e63-b381-bbcca5b2c457",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731814
+  },
+  {
+    "id": "79e8c34b-f262-4e7c-89f8-ec6809ece0be",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731814
+  },
+  {
+    "id": "01784253-bf88-4074-a6fd-6aab337aa30c",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731814
+  },
+  {
+    "id": "7d41149b-1b64-40e8-bd20-1a582b55d29c",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731814
+  },
+  {
+    "id": "2e5c954d-5dc2-4f48-a48a-6b99cdc93c1c",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731814
+  },
+  {
+    "id": "83051360-3736-4a4b-aafe-40df9e9e16ce",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731814
+  },
+  {
+    "id": "c14a1d18-72f5-4333-bba1-f351cedd77a0",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731814
+  },
+  {
+    "id": "c41cd0d6-5e1c-4c9f-8fce-db5566662fc4",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731814
+  },
+  {
+    "id": "e44829cc-8d30-4c22-a458-f96783733029",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731814
+  },
+  {
+    "id": "c7d71662-d7c9-4da5-be52-3ca01180a659",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731814
+  },
+  {
+    "id": "6e94bcfc-da82-4210-bf6d-591899fa1ee7",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731814
+  },
+  {
+    "id": "60e3a4df-27b4-4902-9267-59f1aadb5f87",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731814
+  },
+  {
+    "id": "084e1ede-a3e5-422e-81f5-e389342685d7",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731814
+  },
+  {
+    "id": "a1ce2034-7e51-45ee-a5da-a8d720aeffc5",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731814
+  },
+  {
+    "id": "255c4ddf-bec2-4f2c-b723-d3729d5a869d",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731814
+  },
+  {
+    "id": "0aa16d6f-d165-4025-81c1-0a07a433ef26",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731814
+  },
+  {
+    "id": "f3cb5e76-3834-437d-b2b1-0f0fcdd7cce1",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731814
+  },
+  {
+    "id": "dcbbeeb8-eb41-45be-94b8-e21a83902cf4",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731814
+  },
+  {
+    "id": "c0ad594b-fe0f-4d87-8c7f-a6978631b807",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731814
+  },
+  {
+    "id": "7e76801b-e6c9-4ade-909a-42625f7ce0a1",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731814
+  },
+  {
+    "id": "4ef3c591-10c6-47d3-9957-301647ec10ba",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731814
+  },
+  {
+    "id": "0d93848e-f9fe-4e4d-9856-e5568266e1c9",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731814
+  },
+  {
+    "id": "f6a13b39-09b8-4f12-ad8b-2ab9ffc1051f",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731814
+  },
+  {
+    "id": "d09d03f2-6a41-4584-9cbd-449ee9ffde3f",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731814
+  },
+  {
+    "id": "b1e3fafb-7c87-444d-8cda-e772f9f4a3a1",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731814
+  },
+  {
+    "id": "db1ae68b-68d2-484e-99ff-387df7970222",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731814
+  },
+  {
+    "id": "8647249c-ad66-453a-a651-e708d5787949",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731814
+  },
+  {
+    "id": "32c6d207-047a-4112-8acc-e7b19b04d47b",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731814
+  },
+  {
+    "id": "fe5d6f3d-7709-4cf1-9c0f-b7774c7e0811",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731814
+  },
+  {
+    "id": "4b6f4f98-71c6-447e-9f2a-a19ea86be274",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731814
+  },
+  {
+    "id": "9b6e150b-bd10-429b-a7bd-52adc9e1b133",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731814
+  },
+  {
+    "id": "f004a297-4ef3-4f63-8aa3-45a14bb2f28a",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731814
+  },
+  {
+    "id": "2cf4dbec-09f3-4a39-b267-12d21f8b8637",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731814
+  },
+  {
+    "id": "0ee1332e-bce8-44ce-8425-fa74c337be7a",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731814
+  },
+  {
+    "id": "743a09a3-2f6d-464f-9e1e-46ce4bb845fe",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731814
+  },
+  {
+    "id": "e0a8de47-bd98-4f46-bf42-5aa74d0753ca",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731814
+  },
+  {
+    "id": "0d8d1df5-da8d-4532-ae81-78982c34316e",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731814
+  },
+  {
+    "id": "67a0d99f-4833-411b-87e3-99a2420449cf",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731814
+  },
+  {
+    "id": "58e34d30-505d-4744-9f2d-f2a9eaeabc65",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731814
+  },
+  {
+    "id": "43623554-da55-45a8-a73b-58fa9e5ed042",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731814
+  },
+  {
+    "id": "1d75a1f5-d71b-4d76-b229-c7b7eb443f9e",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731814
+  },
+  {
+    "id": "50ab3cd8-b682-4387-bc92-e05c4af8e48a",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731814
+  },
+  {
+    "id": "78026c44-7dd2-4884-827c-79d9fde620e5",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731814
+  },
+  {
+    "id": "3248b195-cb07-45d3-8a4e-8b7dbc178e88",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731814
+  },
+  {
+    "id": "8c8c24ed-851a-4ebe-b7ff-1f625fda0f41",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731814
+  },
+  {
+    "id": "4a6e96eb-23e3-419a-89d7-43b9380ae9bb",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731814
+  },
+  {
+    "id": "295e4d17-d48e-4f28-bf44-18880090ac0f",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731814
+  },
+  {
+    "id": "27b8fd5e-701a-4983-928d-4f2c158d8715",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731814
+  },
+  {
+    "id": "2e56767c-fa42-4059-b41f-5df95842b1b1",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731814
+  },
+  {
+    "id": "19332878-8ef1-4204-8a28-d6ac1447e80a",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731814
+  },
+  {
+    "id": "46c9bc27-5063-464a-b414-0fa3f617f306",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731814
+  },
+  {
+    "id": "5beb89c1-81e8-487e-9a05-40a78dbe49ce",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731814
+  },
+  {
+    "id": "11cae2c4-8833-4fbe-bffc-d1e1c81f7f15",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731814
+  },
+  {
+    "id": "5f1c4b44-89ad-4e88-a7e0-6838a2452490",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded by ",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731814
+  },
+  {
+    "id": "3ecdafaf-6883-4667-957f-33a1e33b7053",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731814
+  },
+  {
+    "id": "0cedff45-5083-46d6-bcca-2106302f63f8",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731814
+  },
+  {
+    "id": "d192a2d1-8211-4697-8a42-aa4565e36ea8",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731814
+  },
+  {
+    "id": "9f88a352-53db-405c-93f2-b6c1308270cc",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731814
+  },
+  {
+    "id": "b2003983-e0f8-454e-b51a-adb7b78e59d1",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731814
+  },
+  {
+    "id": "a30d97cb-8173-424b-a051-cd750e5bce21",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731814
+  },
+  {
+    "id": "0403327a-8c61-4ab8-80bc-c5817e7693e4",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731815
+  },
+  {
+    "id": "480dbb55-b9a2-43ac-9662-73107f26b61c",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731815
+  },
+  {
+    "id": "99836818-3418-4eda-b366-f95d7f695524",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731815
+  },
+  {
+    "id": "8f3049c6-0def-47e7-ac3b-59e778941b7b",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731815
+  },
+  {
+    "id": "bf8c3f98-7d3e-4db3-968d-122d144a6afe",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731815
+  },
+  {
+    "id": "218d490a-c935-4695-a137-a975f9d3705c",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731815
+  },
+  {
+    "id": "e520612b-1ced-4e17-8dd1-365a859c473f",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731815
+  },
+  {
+    "id": "b5b6153f-b7ae-423d-896f-69e62394b9d6",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731815
+  },
+  {
+    "id": "ff2a1c0c-70ae-4e95-a688-49cd6f871cb5",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731815
+  },
+  {
+    "id": "537c55c4-6c54-4bac-b7a7-3643f63f544c",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731815
+  },
+  {
+    "id": "ae62974d-174c-4910-81e9-f8d3fb1c3b1a",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731815
+  },
+  {
+    "id": "821660b0-7603-43ac-81db-2bad8dac5d11",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731815
+  },
+  {
+    "id": "6ec35451-beb0-4333-a408-9f4262cc9aae",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731815
+  },
+  {
+    "id": "78a4470b-11a4-4825-bcbe-cee1eb6ceb1e",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731815
+  },
+  {
+    "id": "c7649f1c-0723-42df-a1cb-237ef5993803",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731815
+  },
+  {
+    "id": "7875965f-d388-45eb-a799-f97a251cb98a",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731815
+  },
+  {
+    "id": "f2b52c70-9619-4051-9585-14b8fa5d6369",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731815
+  },
+  {
+    "id": "5a216f59-f21f-4f2c-83a0-8821ba256017",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731815
+  },
+  {
+    "id": "9e3300f7-4de3-45d2-87f6-206db5eed385",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731815
+  },
+  {
+    "id": "4249e65b-bf8a-4136-9563-d7160623836f",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731815
+  },
+  {
+    "id": "9224b966-9444-4397-9716-5339a01f6181",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731815
+  },
+  {
+    "id": "a063d0ec-5144-4223-9a7b-28836fce26a9",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731815
+  },
+  {
+    "id": "9045eae0-0c2e-4e99-aa75-b85fc8ce39b6",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731815
+  },
+  {
+    "id": "f2542d2b-5b63-4a5b-862b-42c2cc9192c4",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731815
+  },
+  {
+    "id": "3e479470-9c3c-42f3-8e2c-0cd82254549b",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731815
+  },
+  {
+    "id": "47638c17-0b22-40bb-bbef-65a563c67344",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731815
+  },
+  {
+    "id": "cd4ab99e-c7af-401c-a8c9-125af4c57686",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731815
+  },
+  {
+    "id": "6e7f0d23-7b6d-4c9f-91b0-29c5e5ddcc08",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731815
+  },
+  {
+    "id": "2a9ba05b-6ef4-49a9-b54c-e75e6a4015c4",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731815
+  },
+  {
+    "id": "51e3ba76-0a7e-47b0-8260-0f3200d60109",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " uploaded ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731815
+  },
+  {
+    "id": "e1bd92ba-cdfa-4b29-9c4d-d9083df2b539",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731815
+  },
+  {
+    "id": "323c83f0-7e25-47d1-afbf-1ae1c66842a5",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731815
+  },
+  {
+    "id": "7092953a-fb57-4800-bed8-56f92d3cc763",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731815
+  },
+  {
+    "id": "b9119050-4b92-4842-bf39-9d22cbcae2d2",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731815
+  },
+  {
+    "id": "fa4edbbf-22f3-4577-bc44-db72d76c537d",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731815
+  },
+  {
+    "id": "78802e3e-c9d8-41f0-a902-3eda77edf6ef",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731815
+  },
+  {
+    "id": "aa93930f-a468-4b07-8be5-037d9e49ea75",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731815
+  },
+  {
+    "id": "76537662-4eea-4be0-a0f8-a3ab51794c17",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731815
+  },
+  {
+    "id": "5ddd1184-5b57-4d37-9019-39432705dec8",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731815
+  },
+  {
+    "id": "46d9a569-335b-420d-83de-7a93c1062833",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731815
+  },
+  {
+    "id": "ae60f7e0-fcf3-46a9-a756-ac5a4aba0ac1",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731815
+  },
+  {
+    "id": "ac058866-42ef-4ac0-9ac0-1edf3fca1851",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731815
+  },
+  {
+    "id": "057c5955-c5e4-43b7-8891-9b3f958b4c0c",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731815
+  },
+  {
+    "id": "84a4043f-67b9-4635-8a2d-ae31680c66a9",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731815
+  },
+  {
+    "id": "9bc6b46a-81a7-4ca8-ac9f-d37c1438bcc5",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731815
+  },
+  {
+    "id": "39d74a59-9589-4c4c-ba41-a303756d2aae",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731815
+  },
+  {
+    "id": "67d864a7-458d-4b41-b7ff-3a09d898bc1d",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731815
+  },
+  {
+    "id": "00591a1d-286c-428c-bfd1-33d54f81858a",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " saved ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731815
+  },
+  {
+    "id": "c0ba45c6-af63-42f7-bf75-9f9737ebb7b3",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731815
+  },
+  {
+    "id": "d6b3ef46-8754-4af3-a59f-4e1eb0091120",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731815
+  },
+  {
+    "id": "32f46a86-0a78-4b15-8188-d8ebfb0b156a",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731815
+  },
+  {
+    "id": "70fec4ec-7289-4801-90be-84efd6b2ffca",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731815
+  },
+  {
+    "id": "1eace413-7395-4bed-8ab4-0168ad64a46c",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731815
+  },
+  {
+    "id": "f2140c7f-04da-4cd1-916c-d0773fc7e339",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731815
+  },
+  {
+    "id": "d86e71f0-ed0a-4581-970d-9535360cbde6",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731815
+  },
+  {
+    "id": "342ec1db-5754-445a-a9d8-21155e9c1e19",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731815
+  },
+  {
+    "id": "20d9782e-adae-4903-a3a6-349aa15a8952",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731815
+  },
+  {
+    "id": "47b34981-ea91-42d3-a72e-c4dc42d30c9d",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731815
+  },
+  {
+    "id": "825e1503-f7af-4920-b686-85ef40350e2a",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731815
+  },
+  {
+    "id": "5a276928-94af-4959-980e-9165768e604f",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731815
+  },
+  {
+    "id": "157d6311-d2e8-4e85-af43-4429274cb879",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731815
+  },
+  {
+    "id": "2369f559-37d3-4766-bb83-0466de97f53c",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731815
+  },
+  {
+    "id": "2bbec05b-9a75-4f4f-9672-42f903b3c8e9",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731815
+  },
+  {
+    "id": "f34ffaac-bebd-4fa1-8851-55d78d1083db",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731815
+  },
+  {
+    "id": "589df0be-8c44-49e6-aacf-6c1b5d8f641b",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731815
+  },
+  {
+    "id": "7fe842dd-1449-4259-85e8-9099de921366",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " from the ",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731815
+  },
+  {
+    "id": "3f11b4c8-8412-485d-a118-fc39ec3ddd59",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731815
+  },
+  {
+    "id": "7d9e28d3-6043-4630-ae55-04dfa849b924",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731815
+  },
+  {
+    "id": "54efce59-30e2-4c46-bc49-b01f2b809ef0",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " tagged with ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731815
+  },
+  {
+    "id": "213dbf00-d81f-4241-a94b-7d49aa266973",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731815
+  },
+  {
+    "id": "a9412e85-9378-4cfd-9e79-7c72ab3e6cda",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731815
+  },
+  {
+    "id": "2ce99f07-8b65-4842-94b6-0e8db41a34bf",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " about ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731815
+  },
+  {
+    "id": "a91c8a9d-0f3c-42a0-a016-67d2d3bfded8",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731815
+  },
+  {
+    "id": "7b101fb7-b0d0-416a-ab32-b266e722405e",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731815
+  },
+  {
+    "id": "ce517f08-923d-4645-95dd-aabc396e2973",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " tagged ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731815
+  },
+  {
+    "id": "06a22774-b9e3-4484-93ab-9016176dc251",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731815
+  },
+  {
+    "id": "71f99cc4-0e4d-44be-a062-13a40fefb38c",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731815
+  },
+  {
+    "id": "555d79cc-dadc-43af-826f-ddccc2e86736",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " with tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731815
+  },
+  {
+    "id": "b4bec868-edf0-4d9d-baca-b1fb80c0b246",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731815
+  },
+  {
+    "id": "d7fd95ae-6976-4838-bd05-e54151d0111e",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731815
+  },
+  {
+    "id": "a263bb70-67db-4517-9276-fe62b6e84ffb",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      },
+      {
+        "text": " with the tags ",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731815
+  },
+  {
+    "id": "b33157a1-fdfa-418e-bd24-202d3af14e5c",
+    "data": [
+      {
+        "text": "Get me an image",
+        "userDefined": false
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731815
+  },
+  {
+    "id": "4334c135-7c8d-4941-bb15-fb8a204b2800",
+    "data": [
+      {
+        "text": "I need an image",
+        "userDefined": false
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731815
+  },
+  {
+    "id": "8bfe65f7-0947-48a1-84ca-ed6fc7f4ec1d",
+    "data": [
+      {
+        "text": "Show me an image",
+        "userDefined": false
+      }
+    ],
+    "isTemplate": false,
+    "count": 0,
+    "updated": 1554470731815
   }
 ]

--- a/Agent/intents/Select Team_usersays_en.json
+++ b/Agent/intents/Select Team_usersays_en.json
@@ -1,6 +1,6 @@
 [
   {
-    "id": "ed1e585f-8479-48f8-aca8-1d276a2d2cf7",
+    "id": "47c1166a-c42f-4711-8369-72eb1145bb77",
     "data": [
       {
         "text": "select team ",
@@ -18,7 +18,7 @@
     "updated": 1550852328
   },
   {
-    "id": "05fb0ae5-f704-4f50-8d2f-ee7fd5a5c0a5",
+    "id": "ef36d84c-524e-4179-8139-ef115e0a1456",
     "data": [
       {
         "text": "i am in team ",
@@ -36,7 +36,7 @@
     "updated": 1550852328
   },
   {
-    "id": "32f1304b-994f-49d6-b301-16e2da8164f7",
+    "id": "913383ab-f3ae-42f1-b23f-051baccca767",
     "data": [
       {
         "text": "my team is ",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "minimist": "^1.2.0",
     "nock": "^10.0.2",
     "rimraf": "^2.6.3",
+    "uuid": "^3.3.2",
     "winston": "^3.1.0"
   },
   "devDependencies": {

--- a/src/controller/CarouselFactory.js
+++ b/src/controller/CarouselFactory.js
@@ -10,7 +10,7 @@ export function getHumanReadableTags(image: Image): string {
 export function makeImage(image: Image, params: ConvParams): DialogflowImage {
   return new DialogflowImage({
     url: image.url,
-    alt: `${params.Artifact} with the tags: ${getHumanReadableTags(image)}`,
+    alt: `Image with the tags: ${getHumanReadableTags(image)}`,
   });
 }
 

--- a/src/utility/generateGetArtifactsTrainingPhrases.js
+++ b/src/utility/generateGetArtifactsTrainingPhrases.js
@@ -1,0 +1,152 @@
+const fs = require('fs');
+const uuidv1 = require('uuid/v1');
+
+class TeamSuffix {
+  constructor() {
+    this.phrases = [' from team ', ' from the team '];
+  }
+
+
+  generateStrings() {
+    return this.phrases.map(x => (`
+    {
+        "text": "${x}",
+        "userDefined": false
+      },
+      {
+        "text": "Team",
+        "alias": "Team",
+        "meta": "@Team",
+        "userDefined": true
+      },`)).concat(['']);
+  }
+}
+class AuthorSuffix {
+  constructor() {
+    this.phrases = [' by ', ' uploaded by '];
+  }
+
+  generateStrings() {
+    return this.phrases.map(x => (`
+    {
+        "text": "${x}",
+        "userDefined": false
+      },
+      {
+        "text": "Arne",
+        "alias": "Author",
+        "meta": "@Author",
+        "userDefined": false
+      },`)).concat(['']);
+  }
+}
+class TagSuffix {
+  constructor() {
+    this.phrases = [' tagged with ', ' about ', ' tagged ', ' with tags ', ' with the tags '];
+  }
+
+  generateStrings() {
+    return this.phrases.map(x => (`
+    {
+        "text": "${x}",
+        "userDefined": false
+      },
+      {
+        "text": "tags",
+        "alias": "Tag",
+        "meta": "@sys.any",
+        "userDefined": true
+      },`)).concat(['']);
+  }
+}
+class DateSuffix {
+  constructor() {
+    this.phrases = [' from ', ' uploaded ', ' saved ', ' from the '];
+  }
+
+  generateStrings() {
+    return this.phrases.map(x => (`
+    {
+        "text": "${x}",
+        "userDefined": false
+      },
+      {
+        "text": "3 days ago",
+        "alias": "DatePeriod",
+        "meta": "@sys.date-period",
+        "userDefined": true
+      },`)).concat(['']);
+  }
+}
+
+class PrefixGenerator {
+  constructor() {
+    this.prefixes = ['Get me an image', 'I need an image', 'Show me an image'];
+  }
+
+  generateStrings() {
+    return this.prefixes.map(x => (`,
+    "data": [
+      {
+        "text": "${x}",
+        "userDefined": false
+      },`));
+  }
+}
+
+class SuffixGenerator {
+  constructor() {
+    this.suffixTypes = [new TeamSuffix(), new AuthorSuffix(), new DateSuffix(), new TagSuffix()];
+  }
+
+  generateAllPhrases() {
+    this.allSuffixes = [];
+    this.suffixTypes[0].generateStrings().forEach(
+      string1 => this.suffixTypes[1].generateStrings().forEach(
+        string2 => this.suffixTypes[2].generateStrings().forEach(
+          string3 => this.suffixTypes[3].generateStrings().forEach(
+            string4 => this.allSuffixes.push(string1 + string2 + string3 + string4),
+          ),
+        ),
+      ),
+    );
+    return this.allSuffixes;
+  }
+}
+
+class PhraseGenerator {
+  constructor() {
+    this.prefixGen = new PrefixGenerator();
+    this.suffixGen = new SuffixGenerator();
+  }
+
+  makePhrases() {
+    this.ret = [];
+    this.i = 0;
+    this.suffixGen.generateAllPhrases().forEach(
+      suffix => this.prefixGen.generateStrings().forEach(
+        (prefix) => {
+          this.ret.push(`{
+    "id": "${uuidv1()}"${prefix}${suffix}
+  ],
+  "isTemplate": false,
+  "count": 0,
+  "updated": ${Date.now()}
+}`);
+          this.i += 1;
+        },
+      ),
+    );
+    console.log(`${this.i} training phrases were generated.`);
+
+    return `[
+      ${this.ret}
+      ]`;
+  }
+}
+
+
+const gen = new PhraseGenerator();
+fs.writeFile('test.json', gen.makePhrases(), (err) => {
+  if (err) { console.error(err); }
+});


### PR DESCRIPTION
Author, Date, Tag, Team searches work now on Dialogflow. Configured 810 Training Phrases to support any combination of the Phrases:
'Get me an image', 'I need an image', 'Show me an image'
and the lookups for:
' from team ', ' from the team ' _Teamname_
' by ', ' uploaded by ' _Author_
' from ', ' uploaded ', ' saved ', ' from the ' _Date range_
' tagged with ', ' about ', ' tagged ', ' with tags ', ' with the tags ' _Tags_

They only work in that order because Dialogflow imposes a limit of no more than 2000 Training Phrases for uploads and no more than 1000 for preview in Actions on Google.